### PR TITLE
Expand ~ to home directory using File::HomeDir instead of File::Glob

### DIFF
--- a/t/03_config_file.t
+++ b/t/03_config_file.t
@@ -9,7 +9,6 @@ use Test::More;
 use Config::Tiny;
 use IO::CaptureOutput qw/capture/;
 use File::Basename qw/basename/;
-use File::Glob qw/bsd_glob/;
 use File::Spec;
 use File::Temp qw/tempdir/;
 use File::Path qw/mkpath/;
@@ -67,9 +66,9 @@ is( CPAN::Reporter::Config::_get_config_file(), $config_file,
 my @id_file_cases = (
   [ $metabase_file        => $metabase_file ],
   [ 'metabase_id.json'    => $metabase_file ],
-  [ '/other/path.json'    => '/other/path.json' ],
+  [ '/other/path.json'    => File::Spec->catfile( '/other/', 'path.json' )],
   [ 'other.json'          => File::Spec->catfile( $config_dir, 'other.json' )],
-  [ '~/other.json'        => File::Spec::Unix->catfile( bsd_glob('~'), 'other.json' )],
+  [ '~/other.json'        => File::Spec->catfile( File::HomeDir->my_home, 'other.json' )],
 );
 
 for my $c ( @id_file_cases ) {


### PR DESCRIPTION
Using `File::Glob::bsd_glob` to expand the `~` to the home directory seems easy, but as `File::Glob` itself admits, it doesn't work on very many systems. Notably it does not work on Windows by default (it works if `HOME` is set in the environment, but `HOME` it not set by default in Windows).

This changes `~` expansion to use `File::HomeDir` which is much more portable. It also changes `_normalize_id_file` to normalize the directories to that of the system as well.

I have mainly made this change for the Windows perl users. Unless one of those users sets the `HOME` environment variable (not too likely) then the tests won't pass. The tests will also have issues on any system where `File::Glob::bsd_glob` does not expand `~`. Recently I submitted a [patch to perl](https://rt.perl.org/rt3//Public/Bug/Display.html?id=98812) to expand `~` on Windows, but of course that won't help all the old perls which don't do that. Since this module already uses `File::HomeDir` and `File::Spec` it seemed logical to use those modules for the `~` expansion.
