### PR TITLE
fix tilde expansion on windows vista and beyond

### DIFF
--- a/lib/CPAN/Reporter/Config.pm
+++ b/lib/CPAN/Reporter/Config.pm
@@ -11,6 +11,11 @@ use IPC::Cmd 0.46 ();
 use IO::File ();
 use CPAN 1.9301 (); # for printing warnings
 
+# see https://rt.perl.org/rt3/Public/Bug/Display.html?id=98812
+BEGIN{
+    $ENV{HOME} = $ENV{USERPROFILE} if $^O eq 'MSWin32' and !$ENV{HOME} and $ENV{USERPROFILE};
+}
+
 #--------------------------------------------------------------------------#
 # Back-compatibility checks -- just once per load
 #--------------------------------------------------------------------------#


### PR DESCRIPTION
File::Glob does not work correctly on Vista and beyond due to changes in the environment variables. This is fixed in the perl core, but since File::Glob is not dual-lifed, we'll have to fix it in CPAN::Reporter too, if it should work on Perls released before September 2011. :)

This commit is the minimum change i could think of to make it work.

Also see: https://rt.perl.org/rt3/Public/Bug/Display.html?id=98812
