### PR TITLE
Add XSConfig and cperl support

### DIFF
--- a/t/06_prompt_text.t
+++ b/t/06_prompt_text.t
@@ -19,7 +19,8 @@ use Config;
 
 BEGIN {
     BEGIN { if (not $] < 5.006 ) { warnings->unimport('redefine') } }
-    *Config::STORE = sub { $_[0]->{$_[1]} = $_[2] }
+    plan skip_all => "cperl Config is readonly" if $Config{usecperl};
+    *Config::STORE = sub { $_[0]->{$_[1]} = $_[2] };
 }
 
 # For these tests, hide perl_patchlevel so all prompts are tested
@@ -41,7 +42,7 @@ my $mock_dist = t::MockCPANDist->new(
     author_id       => "JOHNQP",
     author_fullname => "John Q. Public",
 );
-    
+
 my $case = {
     label => "t-Fail",
     name => "t-Fail",
@@ -88,7 +89,7 @@ plan tests => 2 + ( scalar keys %prompts ) + $config_plus_dispatch
 require_ok('CPAN::Reporter');
 require_ok('CPAN::Reporter::History');
 
-test_fake_config( 
+test_fake_config(
         edit_report => "ask/no",
         send_report => "ask/yes",
         send_duplicates => "ask/yes",

--- a/t/06_prompt_text.t
+++ b/t/06_prompt_text.t
@@ -19,7 +19,7 @@ use Config;
 
 BEGIN {
     BEGIN { if (not $] < 5.006 ) { warnings->unimport('redefine') } }
-    plan skip_all => "cperl Config is readonly" if $Config{usecperl};
+    plan skip_all => "XSConfig is readonly" if $Config{usecperl} or exists &Config::KEYS;
     *Config::STORE = sub { $_[0]->{$_[1]} = $_[2] };
 }
 

--- a/t/06_prompt_text.t
+++ b/t/06_prompt_text.t
@@ -8,23 +8,11 @@ use Test::More;
 use t::MockCPANDist;
 use t::Helper;
 use t::Frontend;
-use Config;
 use IO::CaptureOutput;
-
-#--------------------------------------------------------------------------#
-# We need Config to be writeable, so modify the tied hash
-#--------------------------------------------------------------------------#
-
 use Config;
-
-BEGIN {
-    BEGIN { if (not $] < 5.006 ) { warnings->unimport('redefine') } }
-    plan skip_all => "XSConfig is readonly" if $Config{usecperl} or exists &Config::KEYS;
-    *Config::STORE = sub { $_[0]->{$_[1]} = $_[2] };
-}
 
 # For these tests, hide perl_patchlevel so all prompts are tested
-local $Config{perl_patchlevel};
+use t::MockPatchlevel;
 
 #--------------------------------------------------------------------------#
 # Fixtures

--- a/t/65_skipfile.t
+++ b/t/65_skipfile.t
@@ -20,6 +20,7 @@ use Config;
 
 BEGIN {
     BEGIN { if (not $] < 5.006 ) { warnings->unimport('redefine') } }
+    plan skip_all => "cperl Config is readonly" if $Config{usecperl};
     *Config::STORE = sub { $_[0]->{$_[1]} = $_[2] }
 }
 

--- a/t/65_skipfile.t
+++ b/t/65_skipfile.t
@@ -20,7 +20,7 @@ use Config;
 
 BEGIN {
     BEGIN { if (not $] < 5.006 ) { warnings->unimport('redefine') } }
-    plan skip_all => "cperl Config is readonly" if $Config{usecperl};
+    plan skip_all => "XSConfig is readonly" if $Config{usecperl} or exists &Config::KEYS;
     *Config::STORE = sub { $_[0]->{$_[1]} = $_[2] }
 }
 

--- a/t/65_skipfile.t
+++ b/t/65_skipfile.t
@@ -12,24 +12,8 @@ use Config;
 use Probe::Perl;
 use File::Temp;
 
-#--------------------------------------------------------------------------#
-# We need Config to be writeable, so modify the tied hash
-#--------------------------------------------------------------------------#
-
-use Config;
-
-BEGIN {
-    BEGIN { if (not $] < 5.006 ) { warnings->unimport('redefine') } }
-    plan skip_all => "XSConfig is readonly" if $Config{usecperl} or exists &Config::KEYS;
-    *Config::STORE = sub { $_[0]->{$_[1]} = $_[2] }
-}
-
-#--------------------------------------------------------------------------#
-# Fixtures
-#--------------------------------------------------------------------------#
-
 # Need to have bleadperls pretend to be normal for these tests
-local $Config{perl_patchlevel};
+use t::MockPatchlevel;
 
 my $make = $Config{make};
 my $perl = Probe::Perl->find_perl_interpreter();

--- a/t/MockPatchlevel.pm
+++ b/t/MockPatchlevel.pm
@@ -1,0 +1,21 @@
+package t::MockPatchlevel;
+
+# With XSConfig is readonly, so workaround that.
+
+if ($Config::Config{perl_patchlevel}) {
+  if (exists &Config::KEYS) {     # compiled Config
+    *Config_FETCHorig = \&Config::FETCH;
+    no warnings 'redefine';
+    *Config::FETCH = sub {
+      if ($_[0] and $_[1] eq 'patchlevel') {
+        return '';
+      } else {
+        return Config_FETCHorig(@_);
+      }
+    }
+  } else {
+    tied(%Config)->{perl_patchlevel} = '';    # uncompiled Config
+  }
+}
+
+1;


### PR DESCRIPTION
Abstract Config mocking, add t::MockPatchlevel

For certain tests we just need to temp. unset $Config{perl_patchlevel}
which does not work with XSConfig or cperl, which has a true readonly Config hash.
Use the Helper module t::MockPatchlevel for that.
