### PR TITLE
Include Test2 version in toolchain report

### DIFF
--- a/lib/CPAN/Reporter.pm
+++ b/lib/CPAN/Reporter.pm
@@ -1435,6 +1435,7 @@ my @toolchain_mods= qw(
     Parse::CPAN::Meta
     Test::Harness
     Test::More
+    Test2
     YAML
     YAML::Syck
     version


### PR DESCRIPTION
Test2 and Test::More should generally have the same version number, but it's
possible to reinstall an older Test::More so include both in reports.
