### PR TITLE
Standardize contributor name

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,2 @@
 David Golden <dagolden@cpan.org> <xdg@xdg.me>
+J. Maslak <jmaslak@antelope.net>


### PR DESCRIPTION
For personal reasons, I'm wanting my open source contributions to refer to me by initial.