### PR TITLE
avoid File::Copy::Recursive

### DIFF
--- a/t/66_have_tested.t
+++ b/t/66_have_tested.t
@@ -3,7 +3,7 @@ BEGIN{ if (not $] < 5.006) { require warnings; warnings->import } }
 
 use Test::More;
 use Config;
-use File::Copy::Recursive qw/fcopy/;
+use File::Copy qw/copy/;
 use File::Path qw/mkpath/;
 use File::Spec::Functions qw/catdir catfile rel2abs/;
 use File::Temp qw/tempdir/;
@@ -44,7 +44,7 @@ mkpath( $config_dir );
 ok( -d $config_dir, "temporary config dir created" );
 
 # If old history exists, convert it
-fcopy( $sample_history_file, $history_file);
+copy( $sample_history_file, $history_file);
 ok( -f $history_file, "copied sample old history file to config directory");
 
 # make it writeable

--- a/t/72_rename_history.t
+++ b/t/72_rename_history.t
@@ -7,7 +7,7 @@ select(STDOUT); $|=1;
 use Test::More;
 use Config::Tiny;
 use IO::CaptureOutput qw/capture/;
-use File::Copy::Recursive qw/fcopy/;
+use File::Copy qw/copy/;
 use File::Path qw/mkpath/;
 use File::Spec::Functions qw/catdir catfile rel2abs/;
 use File::Temp qw/tempdir/;
@@ -70,7 +70,7 @@ re_require();
 ok( ! -f $old_history_file && ! -f $new_history_file, "still no history files");
 
 # If old history exists, convert it
-fcopy( $sample_old_file, $old_history_file);
+copy( $sample_old_file, $old_history_file);
 ok( -f $old_history_file, "copied sample old history file to config directory");
 re_require();
 like( $stdout, "/Upgrading automatically/", "saw upgrading notice" );


### PR DESCRIPTION
For copying files, we can just use File::Copy.  For copying directories,
we can reimplement what we need using File::Find and File::Copy.

This is a simpler alternative to #89.