### PR TITLE
The 'tempdir' function is nowhere used; don't import it.

### DIFF
--- a/t/03_config_file.t
+++ b/t/03_config_file.t
@@ -11,7 +11,7 @@ use IO::CaptureOutput qw/capture/;
 use File::Basename qw/basename/;
 use File::Glob qw/bsd_glob/;
 use File::Spec;
-use File::Temp qw/tempdir/;
+use File::Temp;
 use File::Path qw/mkpath/;
 use lib 't/lib';
 use Frontend;


### PR DESCRIPTION
All instances of File::Temp in this file use the OO-interface.

(cherry picked from commit 5f6533dc6cb04401f5614f45a59b91d297108f9e)