### PR TITLE
snip in the middle of the log, not a the end (GH #46)

### DIFF
--- a/lib/CPAN/Reporter.pm
+++ b/lib/CPAN/Reporter.pm
@@ -1189,9 +1189,10 @@ sub _report_text {
     my $data = shift;
     my $test_log = join(q{},@{$data->{output}});
     if ( length $test_log > MAX_OUTPUT_LENGTH ) {
-        $test_log = substr( $test_log, 0, MAX_OUTPUT_LENGTH) . "\n";
         my $max_k = int(MAX_OUTPUT_LENGTH/1000) . "K";
-        $test_log .= "\n[Output truncated after $max_k]\n\n";
+        $test_log = substr( $test_log, 0, MAX_OUTPUT_LENGTH/2 ) . "\n\n"
+	    . "[Output truncated because it exceeded $max_k]\n\n"
+	    . substr( $test_log, -(MAX_OUTPUT_LENGTH/2) );
     }
 
     my $comment_body = _comment_text();


### PR DESCRIPTION
Some remarks:
* English native speakers: is the usage of the verb "truncated" still correct if things are removed in the middle and not from the end of something? Or is it better to use something like "snipped" or "cropped"?
* for simplicity, the log is snipped so that the first 0.5MB and the last 0.5MB are kept, disregarding line boundaries

A sample report with a patched CPAN::Reporter: http://www.cpantesters.org/cpan/report/bd752f0c-b4ae-11eb-8155-ec241f24ea8f (search for "[Output truncated because it exceeded 1000K]").