### PR TITLE
travis: test also with newer perls on newer Ubuntus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,31 @@
 language: perl
-sudo: false
+matrix:
+  include:
+    - perl: "5.30"
+      dist: xenial
+    - perl: "5.28"
+      dist: xenial
+    - perl: "5.22"
+      dist: xenial
+    - perl: "5.26"
+      dist: xenial
+    - perl: "5.24-extras"
+      dist: trusty
+    - perl: "5.20"
+      dist: trusty
+    - perl: "5.18"
+      dist: trusty
+    - perl: "5.16"
+      dist: trusty
+    - perl: "5.14"
+      dist: precise
+    - perl: "5.12"
+      dist: trusty
+    - perl: "5.10"
+      dist: trusty
+    - perl: "5.8"
+      dist: trusty
+sudo: true
 script: prove -lr t
 install:
   - cpanm -n -q --skip-satisfied --installdeps .
-perl:
-  - "5.20"
-  - "5.18"
-  - "5.16"
-  - "5.14"
-  - "5.12"
-  - "5.10"


### PR DESCRIPTION
Also, sudo:true is now set so cpanm may install modules without the use of local::lib (the old setup caused some failures on travis-ci, see https://travis-ci.com/github/eserte/CPAN-Reporter/builds/225930429 )