### PR TITLE
Record whether perl was built with taint support enabled or not

### DIFF
--- a/lib/CPAN/Reporter/History.pm
+++ b/lib/CPAN/Reporter/History.pm
@@ -115,7 +115,7 @@ sub have_tested { ## no critic RequireArgUnpacking
 
     # default to current platform
     $args->{perl} = _format_perl_version() unless defined $args->{perl};
-    $args->{archname} = $Config{archname} unless defined $args->{archname};
+    $args->{archname} = _format_archname() unless defined $args->{archname};
     $args->{osvers} = $Config{osvers} unless defined $args->{osvers};
 
     my @found;
@@ -146,8 +146,31 @@ sub _format_history {
     my $grade = uc $result->{grade};
     my $dist_name = $result->{dist_name};
     my $perlver = "perl-" . _format_perl_version();
-    my $platform = "$Config{archname} $Config{osvers}";
-    return "$phase $grade $dist_name ($perlver) $platform\n";
+    my $osvers = $Config{osvers};
+    my $archname = _format_archname();
+    return "$phase $grade $dist_name ($perlver) $archname $osvers\n";
+}
+
+#--------------------------------------------------------------------------#
+# _format_archname --
+#
+# appends info about taint being disabled to Config.pm's archname
+#--------------------------------------------------------------------------#
+
+sub _format_archname {
+    my $archname = $Config{archname};
+    # `taint_disabled` is correctly set as of perl-blead@da791ecc, which will
+    # be in 5.37.12 and later. Before then it is always false (indeed,
+    # non-existent) and the only way to check whether taint is disabled is to
+    # check the ccflags. Before that and its related commits (see
+    # https://github.com/Perl/perl5/pull/20983) were merged it was impossible
+    # to build a clean perl with taint support disabled that passed all its own
+    # tests.
+    if($Config{taint_disabled}) {
+        $archname .= '-silent' if($Config{taint_disabled} eq 'silent');
+        $archname .= '-no-taint-support';
+    }
+    return $archname;
 }
 
 #--------------------------------------------------------------------------#

--- a/t/62_duplicate_reports.t
+++ b/t/62_duplicate_reports.t
@@ -174,9 +174,10 @@ sub history_format {
     $grade = uc $grade;
     my $perl_ver = "perl-" . CPAN::Reporter::History::_perl_version(); 
     $perl_ver .= " patch $Config{perl_patchlevel}" if $Config{perl_patchlevel};
-    my $arch = "$Config{archname} $Config{osvers}";
+    my $arch = CPAN::Reporter::History::_format_archname();
+    my $os = $Config{osvers};
     my $dist_name = $dist->base_id;
-    return "$phase $grade $dist_name ($perl_ver) $arch\n";
+    return "$phase $grade $dist_name ($perl_ver) $arch $os\n";
 }
 
 #--------------------------------------------------------------------------#

--- a/t/66_have_tested.t
+++ b/t/66_have_tested.t
@@ -12,7 +12,7 @@ use Frontend;
 use MockHomeDir;
 
 #plan 'no_plan';
-plan tests => 21;
+plan tests => $Config{taint_disabled} ? 23 : 22;
 
 #--------------------------------------------------------------------------#
 # Fixtures
@@ -82,17 +82,34 @@ is( ref $aoh[0], 'HASH',
     "returned an AoH"
 );
 
+# we don't use _format_archname here because the test is checking both that
+# _format_archname is used correctly in the code and that it *works* correctly
+my $expected_archname =
+    !$Config{taint_disabled}            ? $Config{archname} :
+    $Config{taint_disabled} eq 'silent' ? "$Config{archname}-silent-no-taint-support" :
+                                          "$Config{archname}-no-taint-support";
 is_deeply( $aoh[0], 
     {
         phase => 'test',
         grade => 'PASS',
         dist => 'Wibble-42', 
         perl => CPAN::Reporter::History::_format_perl_version(),
-        archname => $Config{archname},
+        archname => $expected_archname,
         osvers => $Config{osvers},
     },
     "hash fields as expected"
 );
+
+if($Config{taint_disabled}) {
+    like($aoh[0]->{archname}, qr/no-taint-support/, "taint is unsupported, and the history file agrees");
+    if($Config{taint_disabled} eq 'silent') {
+        like($aoh[0]->{archname}, qr/silent-no-taint-support/, "... silently!");
+    } else {
+        unlike($aoh[0]->{archname}, qr/silent-no-taint-support/, "... noisily!");
+    }
+} else {
+    unlike($aoh[0]->{archname}, qr/no-taint-support/, "taint is supported, and the history file agrees");
+}
 
 # just dist returns all reports for that dist on current platform
 @aoh = have_tested( dist => 'Foo-Bar-1.23' );


### PR DESCRIPTION
Now that perl can actually pass its own tests with taint support disabled, CPAN::Reporter needs to pay attention to this so that we can test against the same version of perl with and without this feature. Without this, if you have already tested a dist against a normal perl 5.37.11 (for example) and then try to test against 5.37.11 with no taint support, you'll not send test reports reliably using the second build.

There are no doubt other obscure options that should be dealt with similarly, and can be added later.