### PR TITLE
Adapt to new bailout output in TAP::Harness 3.49

### DIFF
--- a/lib/CPAN/Reporter.pm
+++ b/lib/CPAN/Reporter.pm
@@ -927,6 +927,9 @@ sub _parse_tap_harness {
     elsif ( $line =~ m{Bailout called\.\s+Further testing stopped}ms ) {
         return ( 'fail', 'Bailed out of tests');
     }
+    elsif ( $line =~ m{FAILED--Further testing stopped}ms ) { # TAP::Harness 3.49+
+        return ( 'fail', 'Bailed out of tests');
+    }
     return;
 }
 


### PR DESCRIPTION
TAP::Harness will now display a result overview for bailouts where previously it wouldn't.